### PR TITLE
Lock ejs package version down to point release

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   }, 
   "preferGlobal": true,
   "dependencies": {
-    "ejs": "^2.6.1",
-    "get-stdin": "^6.0.0",
-    "minimist": "^1.2.0"
+    "ejs": "2.6.x",
+    "get-stdin": "6.0.x",
+    "minimist": "1.2.x"
   }
 }


### PR DESCRIPTION
EJS just did a major version rev, and this tool seems to have broken in some situations as a result. Specifically for me the postinstall script is failing when I run the tool in drone. This locks the tool down to a minor version to see if that helps. 

I took a little liberty with how to version packages in package.json; feel free to tell me to swap to another method. 